### PR TITLE
comment out dry_run=FALSE 

### DIFF
--- a/R/highs.R
+++ b/R/highs.R
@@ -55,7 +55,7 @@ highs_optimizer <- function(control = list()) {
             lhs = lhs,
             rhs = rhs,
             offset = obj$constant,
-            dry_run = FALSE,
+            #dry_run = FALSE,
             maximum = model$objective$sense == "max",
             control = control
         )


### PR DESCRIPTION
this throws an error when I attempt to use it within ompr. Commenting it out enables me to run with HiGHS arguments:

`highs_solver_parameters <- list(mip_rel_gap=0.01)

model_solution <- ompr::solve_model(my_ompr_model,
highs_optimizer(control=highs_solver_parameters))`